### PR TITLE
dfa: add dual-stream parallel validation to halve serial dependency chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ TESTS = \
 	decode_next \
 	decode_prev \
 	transcode_utf16 \
-	transcode_utf32
+	transcode_utf32 \
+	dfa_run_dual32 \
+	dfa_run_dual64 \
+	dfa_run_triple32 \
+	dfa_run_triple64
 
 all: test
 
@@ -103,6 +107,18 @@ transcode_utf16: $(TEST_DIR)/transcode_utf16.c utf8_dfa64.h utf8_transcode.h
 transcode_utf32: $(TEST_DIR)/transcode_utf32.c utf8_dfa64.h utf8_transcode.h
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ $(TEST_DIR)/transcode_utf32.c
 
+dfa_run_dual32: $(TEST_DIR)/dfa_run_dual.c utf8_dfa32.h
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ $(TEST_DIR)/dfa_run_dual.c
+
+dfa_run_dual64: $(TEST_DIR)/dfa_run_dual.c utf8_dfa64.h
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -DUTF8_DFA_64 -o $@ $(TEST_DIR)/dfa_run_dual.c
+
+dfa_run_triple32: $(TEST_DIR)/dfa_run_triple.c utf8_dfa32.h
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ $(TEST_DIR)/dfa_run_triple.c
+
+dfa_run_triple64: $(TEST_DIR)/dfa_run_triple.c utf8_dfa64.h
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -DUTF8_DFA_64 -o $@ $(TEST_DIR)/dfa_run_triple.c
+
 test: $(TESTS)
 	./dfa_step32
 	./dfa_step64
@@ -126,6 +142,10 @@ test: $(TESTS)
 	./decode_prev
 	./transcode_utf16
 	./transcode_utf32
+	./dfa_run_dual32
+	./dfa_run_dual64
+	./dfa_run_triple32
+	./dfa_run_triple64
 
 bench: $(BENCH_SRC) utf8_valid.h
 	$(CC) $(CPPFLAGS) $(BENCH_CFLAGS) -o $(BENCH_BIN) $(BENCH_SRC)

--- a/test/dfa_run_dual.c
+++ b/test/dfa_run_dual.c
@@ -1,0 +1,330 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef UTF8_DFA_64
+#  include "utf8_dfa64.h"
+#else
+#  include "utf8_dfa32.h"
+#endif
+
+#include "test_common.h"
+
+static utf8_dfa_state_t dual_run(const char *src, size_t len) {
+  return utf8_dfa_run_dual(UTF8_DFA_ACCEPT, (const unsigned char *)src, len);
+}
+
+static utf8_dfa_state_t ref_run(const char *src, size_t len) {
+  return utf8_dfa_run(UTF8_DFA_ACCEPT, (const unsigned char *)src, len);
+}
+
+static bool dual_accepts(const char *src, size_t len) {
+  return dual_run(src, len) == UTF8_DFA_ACCEPT;
+}
+
+#define EXPECT_ACCEPT(src, len) do { \
+  char _esc[255*4+1]; \
+  TestCount++; \
+  if (!dual_accepts((src), (len))) { \
+    escape_str((src), (len), _esc); \
+    printf("FAIL line %u: expected ACCEPT for \"%s\" (len=%zu)\n", \
+           __LINE__, _esc, (size_t)(len)); \
+    TestFailed++; \
+  } \
+} while (0)
+
+#define EXPECT_REJECT(src, len) do { \
+  char _esc[255*4+1]; \
+  TestCount++; \
+  if (dual_accepts((src), (len))) { \
+    escape_str((src), (len), _esc); \
+    printf("FAIL line %u: expected REJECT for \"%s\" (len=%zu)\n", \
+           __LINE__, _esc, (size_t)(len)); \
+    TestFailed++; \
+  } \
+} while (0)
+
+#define EXPECT_AGREES(src, len) do { \
+  char _esc[255*4+1]; \
+  utf8_dfa_state_t d = dual_run((src), (len)); \
+  utf8_dfa_state_t r = ref_run((src), (len)); \
+  bool d_ok = (d == UTF8_DFA_ACCEPT); \
+  bool r_ok = (r == UTF8_DFA_ACCEPT); \
+  TestCount++; \
+  if (d_ok != r_ok) { \
+    escape_str((src), (len), _esc); \
+    printf("FAIL line %u: dual %s but ref %s for \"%s\" (len=%zu)\n", \
+           __LINE__, d_ok ? "ACCEPT" : "REJECT", \
+           r_ok ? "ACCEPT" : "REJECT", _esc, (size_t)(len)); \
+    TestFailed++; \
+  } \
+} while (0)
+
+static void
+test_empty(void) {
+  EXPECT_ACCEPT("", 0);
+}
+
+static void
+test_single_byte(void) {
+  // len=1: mid=0, first half empty, second half is the single byte
+  EXPECT_ACCEPT("A", 1);
+  EXPECT_REJECT("\x80", 1);
+  EXPECT_REJECT("\xC3", 1);
+}
+
+static void
+test_two_bytes(void) {
+  // len=2: mid=1, split right down the middle
+  EXPECT_ACCEPT("AB", 2);
+  EXPECT_ACCEPT("\xC3\xA9", 2);  // é
+  EXPECT_REJECT("\xC3\xC3", 2);  // truncated + lead
+  EXPECT_REJECT("\x80\x80", 2);  // bare continuations
+}
+
+static void
+test_split_on_continuation(void) {
+  /*
+   * "AB\xC3\xA9CD" (6 bytes) — mid=3 lands on \xA9 (continuation).
+   * The split must back up to index 2 (\xC3) so the 2-byte sequence
+   * stays in the second half.
+   */
+  EXPECT_ACCEPT("AB\xC3\xA9" "CD", 6);
+  EXPECT_AGREES("AB\xC3\xA9" "CD", 6);
+
+  // 3-byte sequence spanning the midpoint
+  // "A\xE2\x82\xAC" (4 bytes) — mid=2 lands on \x82, backs up to 1
+  EXPECT_ACCEPT("A\xE2\x82\xAC", 4);
+  EXPECT_AGREES("A\xE2\x82\xAC", 4);
+
+  // 4-byte sequence near the midpoint
+  // "AB\xF0\x9F\x98\x80CD" (8 bytes) — mid=4 lands on \x98, backs up to 2
+  EXPECT_ACCEPT("AB\xF0\x9F\x98\x80" "CD", 8);
+  EXPECT_AGREES("AB\xF0\x9F\x98\x80" "CD", 8);
+}
+
+static void
+test_unicode_scalar_values(void) {
+  char buf[8];
+
+  // 1-byte: U+0000..U+007F
+  for (uint32_t ord = 0x0000; ord <= 0x007F; ord++) {
+    encode_ord(ord, 1, buf);
+    EXPECT_AGREES(buf, 1);
+  }
+
+  // 2-byte: U+0080..U+07FF
+  for (uint32_t ord = 0x0080; ord <= 0x07FF; ord++) {
+    encode_ord(ord, 2, buf);
+    EXPECT_AGREES(buf, 2);
+  }
+
+  // 3-byte: U+0800..U+FFFF (skip surrogates)
+  for (uint32_t ord = 0x0800; ord <= 0xFFFF; ord++) {
+    if (ord >= 0xD800 && ord <= 0xDFFF)
+      continue;
+    encode_ord(ord, 3, buf);
+    EXPECT_AGREES(buf, 3);
+  }
+
+  // 4-byte: U+10000..U+10FFFF
+  for (uint32_t ord = 0x10000; ord <= 0x10FFFF; ord++) {
+    encode_ord(ord, 4, buf);
+    EXPECT_AGREES(buf, 4);
+  }
+}
+
+static void
+test_surrogates(void) {
+  char buf[3];
+  for (uint32_t ord = 0xD800; ord <= 0xDFFF; ord++) {
+    encode_ord(ord, 3, buf);
+    EXPECT_REJECT(buf, 3);
+  }
+}
+
+static void
+test_non_shortest_form(void) {
+  char buf[4];
+
+  for (uint32_t ord = 0x0000; ord <= 0x007F; ord++) {
+    encode_ord(ord, 2, buf);
+    EXPECT_REJECT(buf, 2);
+  }
+  for (uint32_t ord = 0x0000; ord <= 0x07FF; ord++) {
+    encode_ord(ord, 3, buf);
+    EXPECT_REJECT(buf, 3);
+  }
+  for (uint32_t ord = 0x0000; ord <= 0xFFFF; ord++) {
+    encode_ord(ord, 4, buf);
+    EXPECT_REJECT(buf, 4);
+  }
+}
+
+static void
+test_non_unicode(void) {
+  char buf[4];
+  for (uint32_t ord = 0x110000; ord <= 0x1FFFFF; ord++) {
+    encode_ord(ord, 4, buf);
+    EXPECT_REJECT(buf, 4);
+  }
+}
+
+static void
+test_bare_continuations(void) {
+  char buf[1];
+  for (unsigned b = 0x80; b <= 0xBF; b++) {
+    buf[0] = (char)b;
+    EXPECT_REJECT(buf, 1);
+  }
+}
+
+static void
+test_invalid_in_first_half(void) {
+  // surrogate in first half, valid ASCII in second
+  EXPECT_REJECT("\xED\xA0\x80" "abcdef", 9);
+  EXPECT_AGREES("\xED\xA0\x80" "abcdef", 9);
+}
+
+static void
+test_invalid_in_second_half(void) {
+  // valid ASCII in first half, surrogate in second
+  EXPECT_REJECT("abcdef" "\xED\xA0\x80", 9);
+  EXPECT_AGREES("abcdef" "\xED\xA0\x80", 9);
+}
+
+static void
+test_invalid_in_both_halves(void) {
+  EXPECT_REJECT("\xED\xA0\x80" "\xED\xA0\x80", 6);
+  EXPECT_AGREES("\xED\xA0\x80" "\xED\xA0\x80", 6);
+}
+
+static void
+test_mixed_valid_sequences(void) {
+  // é (2B) + € (3B) + 😀 (4B) = 9 bytes
+  EXPECT_ACCEPT("\xC3\xA9" "\xE2\x82\xAC" "\xF0\x9F\x98\x80", 9);
+  EXPECT_AGREES("\xC3\xA9" "\xE2\x82\xAC" "\xF0\x9F\x98\x80", 9);
+
+  // Reversed order: 😀 + € + é
+  EXPECT_ACCEPT("\xF0\x9F\x98\x80" "\xE2\x82\xAC" "\xC3\xA9", 9);
+  EXPECT_AGREES("\xF0\x9F\x98\x80" "\xE2\x82\xAC" "\xC3\xA9", 9);
+
+  // ASCII padding around multibyte
+  EXPECT_ACCEPT("hello\xC3\xA9world\xE2\x82\xAC!", 16);
+  EXPECT_AGREES("hello\xC3\xA9world\xE2\x82\xAC!", 16);
+}
+
+static void
+test_large_ascii(void) {
+  char buf[256];
+  memset(buf, 'x', sizeof(buf));
+
+  for (size_t len = 0; len <= 256; len++)
+    EXPECT_AGREES(buf, len);
+}
+
+static void
+test_large_multibyte(void) {
+  // 128 × é = 256 bytes of 2-byte sequences
+  char buf[256];
+  for (size_t i = 0; i < 256; i += 2) {
+    buf[i]     = (char)0xC3;
+    buf[i + 1] = (char)0xA9;
+  }
+
+  for (size_t len = 0; len <= 256; len += 2)
+    EXPECT_AGREES(buf, len);
+}
+
+static void
+test_large_with_error_at_every_position(void) {
+  /*
+   * 32 bytes of valid ASCII with a single bare continuation injected
+   * at each position in turn. Exercises the split landing before,
+   * after, and on the error byte.
+   */
+  char buf[32];
+  memset(buf, 'A', sizeof(buf));
+
+  for (size_t pos = 0; pos < 32; pos++) {
+    buf[pos] = (char)0x80;
+    EXPECT_REJECT(buf, 32);
+    EXPECT_AGREES(buf, 32);
+    buf[pos] = 'A';
+  }
+}
+
+static void
+test_incoming_state(void) {
+  utf8_dfa_state_t st;
+
+  /*
+   * Feed the lead byte of a 2-byte sequence into step,
+   * then hand the continuation + extra bytes to run_dual.
+   * Need len >= 2 so that mid >= 1 and the continuation
+   * lands in the first half where the incoming state applies.
+   */
+  st = utf8_dfa_step(UTF8_DFA_ACCEPT, 0xC3);
+  TestCount++;
+  if (utf8_dfa_run_dual(st, (const unsigned char *)"\xA9X", 2) != UTF8_DFA_ACCEPT) {
+    printf("FAIL line %u: incoming state with valid continuation\n", __LINE__);
+    TestFailed++;
+  }
+
+  // Same lead byte, but continuation is wrong (0x00 is ASCII, not 0x80-0xBF).
+  st = utf8_dfa_step(UTF8_DFA_ACCEPT, 0xC3);
+  TestCount++;
+  if (utf8_dfa_run_dual(st, (const unsigned char *)"\x00X", 2) == UTF8_DFA_ACCEPT) {
+    printf("FAIL line %u: incoming state with invalid continuation should reject\n", __LINE__);
+    TestFailed++;
+  }
+
+  // With len=1, mid=0: the first half is empty, so a non-ACCEPT
+  // incoming state has no bytes to complete the sequence — must reject.
+  st = utf8_dfa_step(UTF8_DFA_ACCEPT, 0xC3);
+  TestCount++;
+  if (utf8_dfa_run_dual(st, (const unsigned char *)"\xA9", 1) == UTF8_DFA_ACCEPT) {
+    printf("FAIL line %u: incoming mid-sequence state with len=1 should reject "
+           "(first half is empty)\n", __LINE__);
+    TestFailed++;
+  }
+}
+
+
+static void
+test_exhaustive_2byte(void) {
+  char buf[2];
+  for (unsigned b0 = 0; b0 < 256; b0++) {
+    for (unsigned b1 = 0; b1 < 256; b1++) {
+      buf[0] = (char)b0;
+      buf[1] = (char)b1;
+      EXPECT_AGREES(buf, 2);
+    }
+  }
+}
+
+int
+main(void) {
+  test_empty();
+  test_single_byte();
+  test_two_bytes();
+  test_split_on_continuation();
+  test_unicode_scalar_values();
+  test_surrogates();
+  test_non_shortest_form();
+  test_non_unicode();
+  test_bare_continuations();
+  test_invalid_in_first_half();
+  test_invalid_in_second_half();
+  test_invalid_in_both_halves();
+  test_mixed_valid_sequences();
+  test_large_ascii();
+  test_large_multibyte();
+  test_large_with_error_at_every_position();
+  test_incoming_state();
+  test_exhaustive_2byte();
+  return report_results();
+}

--- a/test/dfa_run_triple.c
+++ b/test/dfa_run_triple.c
@@ -1,0 +1,404 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef UTF8_DFA_64
+#  include "utf8_dfa64.h"
+#else
+#  include "utf8_dfa32.h"
+#endif
+
+#include "test_common.h"
+
+static utf8_dfa_state_t triple_run(const char *src, size_t len) {
+  return utf8_dfa_run_triple(UTF8_DFA_ACCEPT, (const unsigned char *)src, len);
+}
+
+static utf8_dfa_state_t ref_run(const char *src, size_t len) {
+  return utf8_dfa_run(UTF8_DFA_ACCEPT, (const unsigned char *)src, len);
+}
+
+static bool triple_accepts(const char *src, size_t len) {
+  return triple_run(src, len) == UTF8_DFA_ACCEPT;
+}
+
+#define EXPECT_ACCEPT(src, len) do { \
+  char _esc[255*4+1]; \
+  TestCount++; \
+  if (!triple_accepts((src), (len))) { \
+    escape_str((src), (len), _esc); \
+    printf("FAIL line %u: expected ACCEPT for \"%s\" (len=%zu)\n", \
+           __LINE__, _esc, (size_t)(len)); \
+    TestFailed++; \
+  } \
+} while (0)
+
+#define EXPECT_REJECT(src, len) do { \
+  char _esc[255*4+1]; \
+  TestCount++; \
+  if (triple_accepts((src), (len))) { \
+    escape_str((src), (len), _esc); \
+    printf("FAIL line %u: expected REJECT for \"%s\" (len=%zu)\n", \
+           __LINE__, _esc, (size_t)(len)); \
+    TestFailed++; \
+  } \
+} while (0)
+
+#define EXPECT_AGREES(src, len) do { \
+  char _esc[255*4+1]; \
+  utf8_dfa_state_t t = triple_run((src), (len)); \
+  utf8_dfa_state_t r = ref_run((src), (len)); \
+  bool t_ok = (t == UTF8_DFA_ACCEPT); \
+  bool r_ok = (r == UTF8_DFA_ACCEPT); \
+  TestCount++; \
+  if (t_ok != r_ok) { \
+    escape_str((src), (len), _esc); \
+    printf("FAIL line %u: triple %s but ref %s for \"%s\" (len=%zu)\n", \
+           __LINE__, t_ok ? "ACCEPT" : "REJECT", \
+           r_ok ? "ACCEPT" : "REJECT", _esc, (size_t)(len)); \
+    TestFailed++; \
+  } \
+} while (0)
+
+static void
+test_empty(void) {
+  EXPECT_ACCEPT("", 0);
+}
+
+static void
+test_single_byte(void) {
+  EXPECT_ACCEPT("A", 1);
+  EXPECT_REJECT("\x80", 1);
+  EXPECT_REJECT("\xC3", 1);
+}
+
+static void
+test_two_bytes(void) {
+  EXPECT_ACCEPT("AB", 2);
+  EXPECT_ACCEPT("\xC3\xA9", 2);
+  EXPECT_REJECT("\xC3\xC3", 2);
+  EXPECT_REJECT("\x80\x80", 2);
+}
+
+static void
+test_three_bytes(void) {
+  // Exactly 3 bytes: one byte per segment (ideal split) 
+  EXPECT_ACCEPT("ABC", 3);
+  EXPECT_ACCEPT("\xE2\x82\xAC", 3);  // € 
+  EXPECT_REJECT("\xED\xA0\x80", 3);  // surrogate 
+}
+
+// --- Split-point boundary alignment --- 
+
+static void
+test_split_on_continuation(void) {
+  /*
+   * "AB\xC3\xA9CD" (6 bytes):
+   *   m0 = 2, m1 = 4.  m1 lands on 'C' (ASCII, fine).
+   *   If m0 landed on a continuation it would back up.
+   */
+  EXPECT_ACCEPT("AB\xC3\xA9" "CD", 6);
+  EXPECT_AGREES("AB\xC3\xA9" "CD", 6);
+
+  /*
+   * "A\xE2\x82\xAC" "BC" (6 bytes):
+   *   m0 = 2 lands on \x82 (continuation), backs up to 1.
+   *   m1 = 4 lands on 'B' (ASCII, fine).
+   */
+  EXPECT_ACCEPT("A\xE2\x82\xAC" "BC", 6);
+  EXPECT_AGREES("A\xE2\x82\xAC" "BC", 6);
+
+  /*
+   * 4-byte sequence spanning a split point:
+   * "AB\xF0\x9F\x98\x80" "CD\xC3\xA9" (10 bytes)
+   *   m0 = 3 lands on \x9F (cont), backs up to 2.
+   *   m1 = 6 lands on 'C' (ASCII, fine).
+   */
+  EXPECT_ACCEPT("AB\xF0\x9F\x98\x80" "CD\xC3\xA9", 10);
+  EXPECT_AGREES("AB\xF0\x9F\x98\x80" "CD\xC3\xA9", 10);
+
+  /*
+   * Both split points land on continuations:
+   * "\xE2\x82\xAC\xE2\x82\xAC\xE2\x82\xAC" (9 bytes, 3 × €)
+   *   m0 = 3 lands on \xE2 (lead, fine).
+   *   m1 = 6 lands on \xE2 (lead, fine).
+   */
+  EXPECT_ACCEPT("\xE2\x82\xAC\xE2\x82\xAC\xE2\x82\xAC", 9);
+  EXPECT_AGREES("\xE2\x82\xAC\xE2\x82\xAC\xE2\x82\xAC", 9);
+
+  // 3 × 😀 = 12 bytes. m0=4, m1=8 — lands exactly on sequence boundaries.
+  EXPECT_ACCEPT(
+    "\xF0\x9F\x98\x80\xF0\x9F\x98\x80\xF0\x9F\x98\x80", 12);
+  EXPECT_AGREES(
+    "\xF0\x9F\x98\x80\xF0\x9F\x98\x80\xF0\x9F\x98\x80", 12);
+}
+
+static void
+test_unicode_scalar_values(void) {
+  char buf[8];
+
+  for (uint32_t ord = 0x0000; ord <= 0x007F; ord++) {
+    encode_ord(ord, 1, buf);
+    EXPECT_AGREES(buf, 1);
+  }
+
+  for (uint32_t ord = 0x0080; ord <= 0x07FF; ord++) {
+    encode_ord(ord, 2, buf);
+    EXPECT_AGREES(buf, 2);
+  }
+
+  for (uint32_t ord = 0x0800; ord <= 0xFFFF; ord++) {
+    if (ord >= 0xD800 && ord <= 0xDFFF)
+      continue;
+    encode_ord(ord, 3, buf);
+    EXPECT_AGREES(buf, 3);
+  }
+
+  for (uint32_t ord = 0x10000; ord <= 0x10FFFF; ord++) {
+    encode_ord(ord, 4, buf);
+    EXPECT_AGREES(buf, 4);
+  }
+}
+
+static void
+test_surrogates(void) {
+  char buf[3];
+  for (uint32_t ord = 0xD800; ord <= 0xDFFF; ord++) {
+    encode_ord(ord, 3, buf);
+    EXPECT_REJECT(buf, 3);
+  }
+}
+
+static void
+test_non_shortest_form(void) {
+  char buf[4];
+
+  for (uint32_t ord = 0x0000; ord <= 0x007F; ord++) {
+    encode_ord(ord, 2, buf);
+    EXPECT_REJECT(buf, 2);
+  }
+  for (uint32_t ord = 0x0000; ord <= 0x07FF; ord++) {
+    encode_ord(ord, 3, buf);
+    EXPECT_REJECT(buf, 3);
+  }
+  for (uint32_t ord = 0x0000; ord <= 0xFFFF; ord++) {
+    encode_ord(ord, 4, buf);
+    EXPECT_REJECT(buf, 4);
+  }
+}
+
+static void
+test_non_unicode(void) {
+  char buf[4];
+  for (uint32_t ord = 0x110000; ord <= 0x1FFFFF; ord++) {
+    encode_ord(ord, 4, buf);
+    EXPECT_REJECT(buf, 4);
+  }
+}
+
+static void
+test_bare_continuations(void) {
+  char buf[1];
+  for (unsigned b = 0x80; b <= 0xBF; b++) {
+    buf[0] = (char)b;
+    EXPECT_REJECT(buf, 1);
+  }
+}
+
+static void
+test_invalid_in_first_third(void) {
+  // surrogate in first third, valid rest 
+  EXPECT_REJECT("\xED\xA0\x80" "abcdefghi", 12);
+  EXPECT_AGREES("\xED\xA0\x80" "abcdefghi", 12);
+}
+
+static void
+test_invalid_in_second_third(void) {
+  // valid first, surrogate in middle, valid last 
+  EXPECT_REJECT("abcd" "\xED\xA0\x80" "efgh", 11);
+  EXPECT_AGREES("abcd" "\xED\xA0\x80" "efgh", 11);
+}
+
+static void
+test_invalid_in_third_third(void) {
+  // valid first two thirds, surrogate at end 
+  EXPECT_REJECT("abcdefghi" "\xED\xA0\x80", 12);
+  EXPECT_AGREES("abcdefghi" "\xED\xA0\x80", 12);
+}
+
+static void
+test_invalid_in_all_thirds(void) {
+  EXPECT_REJECT("\xED\xA0\x80" "\xED\xA0\x80" "\xED\xA0\x80", 9);
+  EXPECT_AGREES("\xED\xA0\x80" "\xED\xA0\x80" "\xED\xA0\x80", 9);
+}
+
+static void
+test_mixed_valid_sequences(void) {
+  // é + € + 😀 = 9 bytes 
+  EXPECT_ACCEPT("\xC3\xA9" "\xE2\x82\xAC" "\xF0\x9F\x98\x80", 9);
+  EXPECT_AGREES("\xC3\xA9" "\xE2\x82\xAC" "\xF0\x9F\x98\x80", 9);
+
+  // 😀 + € + é (reversed) 
+  EXPECT_ACCEPT("\xF0\x9F\x98\x80" "\xE2\x82\xAC" "\xC3\xA9", 9);
+  EXPECT_AGREES("\xF0\x9F\x98\x80" "\xE2\x82\xAC" "\xC3\xA9", 9);
+
+  // ASCII padding around multibyte 
+  EXPECT_ACCEPT("hello\xC3\xA9world\xE2\x82\xAC!", 16);
+  EXPECT_AGREES("hello\xC3\xA9world\xE2\x82\xAC!", 16);
+}
+
+static void
+test_large_ascii(void) {
+  char buf[256];
+  memset(buf, 'x', sizeof(buf));
+
+  for (size_t len = 0; len <= 256; len++)
+    EXPECT_AGREES(buf, len);
+}
+
+static void
+test_large_multibyte(void) {
+  // 128 × é = 256 bytes 
+  char buf[256];
+  for (size_t i = 0; i < 256; i += 2) {
+    buf[i]     = (char)0xC3;
+    buf[i + 1] = (char)0xA9;
+  }
+
+  for (size_t len = 0; len <= 256; len += 2)
+    EXPECT_AGREES(buf, len);
+}
+
+static void
+test_large_3byte(void) {
+  // 85 × € (255 bytes) + 1 ASCII = 256 bytes 
+  char buf[256];
+  for (size_t i = 0; i + 2 < 256; i += 3) {
+    buf[i]     = (char)0xE2;
+    buf[i + 1] = (char)0x82;
+    buf[i + 2] = (char)0xAC;
+  }
+  buf[255] = 'Z';
+
+  EXPECT_AGREES(buf, 256);
+
+  // Test at sequence-aligned lengths 
+  for (size_t len = 0; len <= 255; len += 3)
+    EXPECT_AGREES(buf, len);
+}
+
+static void
+test_large_with_error_at_every_position(void) {
+  char buf[48];
+  memset(buf, 'A', sizeof(buf));
+
+  for (size_t pos = 0; pos < 48; pos++) {
+    buf[pos] = (char)0x80;
+    EXPECT_REJECT(buf, 48);
+    EXPECT_AGREES(buf, 48);
+    buf[pos] = 'A';
+  }
+}
+
+// --- Uneven segment lengths due to boundary alignment --- 
+
+static void
+test_uneven_segments(void) {
+  /*
+   * 4-byte seq at the very start forces m0 to back up to 0,
+   * making the first segment empty and the other two large.
+   * "\xF0\x9F\x98\x80" + 8 ASCII = 12 bytes
+   *   m0 = 4, m1 = 8, both on ASCII boundaries — even split.
+   */
+  EXPECT_ACCEPT("AAAAA\xF0\x9F\x98\x80""AAA", 12);
+  EXPECT_AGREES("AAAAA\xF0\x9F\x98\x80""AAA", 12);
+
+  // All 4-byte sequences: forces heavy boundary adjustment 
+  EXPECT_ACCEPT(
+    "\xF0\x9F\x98\x80" "\xF0\x9F\x98\x81" "\xF0\x9F\x98\x82"
+    "\xF0\x9F\x98\x83" "\xF0\x9F\x98\x84", 20);
+  EXPECT_AGREES(
+    "\xF0\x9F\x98\x80" "\xF0\x9F\x98\x81" "\xF0\x9F\x98\x82"
+    "\xF0\x9F\x98\x83" "\xF0\x9F\x98\x84", 20);
+}
+
+// --- Propagation of incoming state --- 
+
+static void
+test_incoming_state(void) {
+  utf8_dfa_state_t st;
+
+  /*
+   * Need len >= 3 so all three segments get bytes and the
+   * continuation lands in the first segment.
+   */
+  st = utf8_dfa_step(UTF8_DFA_ACCEPT, 0xC3);
+  TestCount++;
+  if (utf8_dfa_run_triple(st, (const unsigned char *)"\xA9XY", 3) != UTF8_DFA_ACCEPT) {
+    printf("FAIL line %u: incoming state with valid continuation\n", __LINE__);
+    TestFailed++;
+  }
+
+  st = utf8_dfa_step(UTF8_DFA_ACCEPT, 0xC3);
+  TestCount++;
+  if (utf8_dfa_run_triple(st, (const unsigned char *)"\x00XY", 3) == UTF8_DFA_ACCEPT) {
+    printf("FAIL line %u: incoming state with invalid continuation should reject\n", __LINE__);
+    TestFailed++;
+  }
+
+  /*
+   * With len=1, m0=0: first segment is empty, incoming mid-sequence
+   * state can't complete — must reject.
+   */
+  st = utf8_dfa_step(UTF8_DFA_ACCEPT, 0xC3);
+  TestCount++;
+  if (utf8_dfa_run_triple(st, (const unsigned char *)"\xA9", 1) == UTF8_DFA_ACCEPT) {
+    printf("FAIL line %u: incoming mid-sequence state with len=1 should reject "
+           "(first segment is empty)\n", __LINE__);
+    TestFailed++;
+  }
+}
+
+// --- Exhaustive 2-byte agreement --- 
+
+static void
+test_exhaustive_2byte(void) {
+  char buf[2];
+  for (unsigned b0 = 0; b0 < 256; b0++) {
+    for (unsigned b1 = 0; b1 < 256; b1++) {
+      buf[0] = (char)b0;
+      buf[1] = (char)b1;
+      EXPECT_AGREES(buf, 2);
+    }
+  }
+}
+
+int
+main(void) {
+  test_empty();
+  test_single_byte();
+  test_two_bytes();
+  test_three_bytes();
+  test_split_on_continuation();
+  test_unicode_scalar_values();
+  test_surrogates();
+  test_non_shortest_form();
+  test_non_unicode();
+  test_bare_continuations();
+  test_invalid_in_first_third();
+  test_invalid_in_second_third();
+  test_invalid_in_third_third();
+  test_invalid_in_all_thirds();
+  test_mixed_valid_sequences();
+  test_large_ascii();
+  test_large_multibyte();
+  test_large_3byte();
+  test_large_with_error_at_every_position();
+  test_uneven_segments();
+  test_incoming_state();
+  test_exhaustive_2byte();
+  return report_results();
+}

--- a/utf8_dfa32.h
+++ b/utf8_dfa32.h
@@ -378,6 +378,77 @@ static inline utf8_dfa_state_t utf8_dfa_run16(utf8_dfa_state_t state,
   return state & 31;
 }
 
+static inline utf8_dfa_state_t utf8_dfa_run_dual(utf8_dfa_state_t state,
+                                                 const unsigned char *src,
+                                                 size_t len) {
+  size_t mid = len / 2;
+  while (mid > 0 && (src[mid] & 0xC0) == 0x80)
+    mid--;
+
+  utf8_dfa_state_t s0 = state;
+  utf8_dfa_state_t s1 = UTF8_DFA_ACCEPT;
+
+  #pragma GCC unroll 4
+  for (size_t i = 0, j = mid; i < mid; i++, j++) {
+    s0 = utf8_dfa[src[i]] >> (s0 & 31);
+    s1 = utf8_dfa[src[j]] >> (s1 & 31);
+  }
+
+  for (size_t j = mid * 2; j < len; j++)
+    s1 = utf8_dfa[src[j]] >> (s1 & 31);
+
+  s0 &= 31;
+  s1 &= 31;
+
+  if (s0 != UTF8_DFA_ACCEPT)
+    return UTF8_DFA_REJECT;
+  return s1;
+}
+
+static inline utf8_dfa_state_t utf8_dfa_run_triple(utf8_dfa_state_t state,
+                                                   const unsigned char* src,
+                                                   size_t len) {
+  size_t m0 = len / 3;
+  size_t m1 = len * 2 / 3;
+
+  while (m0 > 0 && (src[m0] & 0xC0) == 0x80)
+    m0--;
+  while (m1 > m0 && (src[m1] & 0xC0) == 0x80)
+    m1--;
+
+  size_t len0 = m0;
+  size_t len1 = m1 - m0;
+  size_t len2 = len - m1;
+  size_t n = len0 < len1 ? len0 : len1;
+  if (len2 < n)
+    n = len2;
+
+  utf8_dfa_state_t s0 = state;
+  utf8_dfa_state_t s1 = UTF8_DFA_ACCEPT;
+  utf8_dfa_state_t s2 = UTF8_DFA_ACCEPT;
+
+  for (size_t i = 0; i < n; i++) {
+    s0 = utf8_dfa[src[i]] >> (s0 & 31);
+    s1 = utf8_dfa[src[m0 + i]] >> (s1 & 31);
+    s2 = utf8_dfa[src[m1 + i]] >> (s2 & 31);
+  }
+
+  for (size_t i = n; i < len0; i++)
+    s0 = utf8_dfa[src[i]] >> (s0 & 31);
+  for (size_t i = n; i < len1; i++)
+    s1 = utf8_dfa[src[m0 + i]] >> (s1 & 31);
+  for (size_t i = n; i < len2; i++)
+    s2 = utf8_dfa[src[m1 + i]] >> (s2 & 31);
+
+  s0 &= 31;
+  s1 &= 31;
+  s2 &= 31;
+
+  if (s0 != UTF8_DFA_ACCEPT || s1 != UTF8_DFA_ACCEPT)
+    return UTF8_DFA_REJECT;
+  return s2;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/utf8_dfa64.h
+++ b/utf8_dfa64.h
@@ -413,6 +413,77 @@ static inline utf8_dfa_state_t utf8_dfa_run16(utf8_dfa_state_t state,
   return state & 63;
 }
 
+static inline utf8_dfa_state_t utf8_dfa_run_dual(utf8_dfa_state_t state,
+                                                 const unsigned char *src,
+                                                 size_t len) {
+  size_t mid = len / 2;
+  while (mid > 0 && (src[mid] & 0xC0) == 0x80)
+    mid--;
+
+  utf8_dfa_state_t s0 = state;
+  utf8_dfa_state_t s1 = UTF8_DFA_ACCEPT;
+
+  #pragma GCC unroll 4
+  for (size_t i = 0, j = mid; i < mid; i++, j++) {
+    s0 = utf8_dfa[src[i]] >> (s0 & 63);
+    s1 = utf8_dfa[src[j]] >> (s1 & 63);
+  }
+
+  for (size_t j = mid * 2; j < len; j++)
+    s1 = utf8_dfa[src[j]] >> (s1 & 63);
+
+  s0 &= 63;
+  s1 &= 63;
+
+  if (s0 != UTF8_DFA_ACCEPT)
+    return UTF8_DFA_REJECT;
+  return s1;
+}
+
+static inline utf8_dfa_state_t utf8_dfa_run_triple(utf8_dfa_state_t state,
+                                                   const unsigned char* src,
+                                                   size_t len) {
+  size_t m0 = len / 3;
+  size_t m1 = len * 2 / 3;
+
+  while (m0 > 0 && (src[m0] & 0xC0) == 0x80)
+    m0--;
+  while (m1 > m0 && (src[m1] & 0xC0) == 0x80)
+    m1--;
+
+  size_t len0 = m0;
+  size_t len1 = m1 - m0;
+  size_t len2 = len - m1;
+  size_t n = len0 < len1 ? len0 : len1;
+  if (len2 < n)
+    n = len2;
+
+  utf8_dfa_state_t s0 = state;
+  utf8_dfa_state_t s1 = UTF8_DFA_ACCEPT;
+  utf8_dfa_state_t s2 = UTF8_DFA_ACCEPT;
+
+  for (size_t i = 0; i < n; i++) {
+    s0 = utf8_dfa[src[i]] >> (s0 & 63);
+    s1 = utf8_dfa[src[m0 + i]] >> (s1 & 63);
+    s2 = utf8_dfa[src[m1 + i]] >> (s2 & 63);
+  }
+
+  for (size_t i = n; i < len0; i++)
+    s0 = utf8_dfa[src[i]] >> (s0 & 63);
+  for (size_t i = n; i < len1; i++)
+    s1 = utf8_dfa[src[m0 + i]] >> (s1 & 63);
+  for (size_t i = n; i < len2; i++)
+    s2 = utf8_dfa[src[m1 + i]] >> (s2 & 63);
+
+  s0 &= 63;
+  s1 &= 63;
+  s2 &= 63;
+
+  if (s0 != UTF8_DFA_ACCEPT || s1 != UTF8_DFA_ACCEPT)
+    return UTF8_DFA_REJECT;
+  return s2;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/utf8_valid.h
+++ b/utf8_valid.h
@@ -79,28 +79,20 @@ static inline size_t utf8_maximal_prefix(const char* src, size_t len) {
 }
 
 static inline bool utf8_check(const char* src,
-                              size_t slen,
+                              size_t len,
                               size_t* cursor) {
   const unsigned char* s = (const unsigned char*)src;
-  size_t len = slen;
   utf8_dfa_state_t state = UTF8_DFA_ACCEPT;
 
-  // Process 16-byte chunks
-  while (len >= 16) {
-    state = utf8_dfa_run16(state, s);
-    s += 16;
-    len -= 16;
-  }
-
-  state = utf8_dfa_run(state, s, len);
+  state = utf8_dfa_run_dual(state, s, len);
   if (state == UTF8_DFA_ACCEPT) {
     if (cursor)
-      *cursor = slen;
+      *cursor = len;
     return true;
   }
 
   if (cursor)
-    *cursor = utf8_maximal_prefix(src, slen);
+    *cursor = utf8_maximal_prefix(src, len);
   return false;
 }
 


### PR DESCRIPTION
Splits validation into two independent DFA streams running in lockstep.
The CPU's out-of-order engine can execute both chains simultaneously
since s0 and s1 have no data dependency between each other.
Also adds a triple-stream variant.